### PR TITLE
Right DST changeover.

### DIFF
--- a/NTPtimeESP.cpp
+++ b/NTPtimeESP.cpp
@@ -196,13 +196,13 @@ boolean NTPtime::daylightSavingTime(unsigned long _timeStamp) {
 	if (previousSunday < 1)
 	{
 		// is not true for Sunday after 2am or any day after 1st Sunday any time
-		return ((_tempDateTime.dayofWeek == 1 && _tempDateTime.hour < 2) || (_tempDateTime.dayofWeek > 1));
+		return ((_tempDateTime.dayofWeek == 1 && _tempDateTime.hour < 1) || (_tempDateTime.dayofWeek > 1));
 		//return true;
 	} // end if (previousSunday < 1)
 	else
 	{
 		// return false unless after first wk and dow = Sunday and hour < 2
-		return (_tempDateTime.day <8 && _tempDateTime.dayofWeek == 1 && _tempDateTime.hour < 2);
+		return (_tempDateTime.day <8 && _tempDateTime.dayofWeek == 1 && _tempDateTime.hour < 1);
 	}  // end else
 } // end boolean NTPtime::daylightSavingTime(unsigned long _timeStamp)
 
@@ -210,8 +210,8 @@ boolean NTPtime::daylightSavingTime(unsigned long _timeStamp) {
 unsigned long NTPtime::adjustTimeZone(unsigned long _timeStamp, float _timeZone, int _DayLightSaving) {
 	
 	if (_DayLightSaving ==1 && summerTime(_timeStamp)) _timeStamp += 3600; // European Summer time
-	if (_DayLightSaving ==2 && daylightSavingTime(_timeStamp)) _timeStamp += 3600; // US daylight time
 	_timeStamp += (unsigned long)(_timeZone *  3600.0); // adjust timezone
+	if (_DayLightSaving ==2 && daylightSavingTime(_timeStamp)) _timeStamp += 3600; // US daylight time
 	return _timeStamp;
 }
 

--- a/NTPtimeESP.cpp
+++ b/NTPtimeESP.cpp
@@ -150,7 +150,7 @@ boolean NTPtime::summerTime(unsigned long _timeStamp ) {
 
 	if (_tempDateTime.month < 3 || _tempDateTime.month > 10) return false; // keine Sommerzeit in Jan, Feb, Nov, Dez
 	if (_tempDateTime.month > 3 && _tempDateTime.month < 10) return true; // Sommerzeit in Apr, Mai, Jun, Jul, Aug, Sep
-	if (_tempDateTime.month == 3 && (_tempDateTime.hour + 24 * _tempDateTime.day) >= (3 +  24 * (31 - (5 * _tempDateTime.year / 4 + 4) % 7)) || _tempDateTime.month == 10 && (_tempDateTime.hour + 24 * _tempDateTime.day) < (3 +  24 * (31 - (5 * _tempDateTime.year / 4 + 1) % 7)))
+	if (_tempDateTime.month == 3 && (_tempDateTime.hour + 24 * _tempDateTime.day) >= (1 +  24 * (31 - (5 * _tempDateTime.year / 4 + 4) % 7)) || _tempDateTime.month == 10 && (_tempDateTime.hour + 24 * _tempDateTime.day) < (1 +  24 * (31 - (5 * _tempDateTime.year / 4 + 1) % 7)))
 	return true;
 	else
 	return false;
@@ -208,10 +208,10 @@ boolean NTPtime::daylightSavingTime(unsigned long _timeStamp) {
 
 
 unsigned long NTPtime::adjustTimeZone(unsigned long _timeStamp, float _timeZone, int _DayLightSaving) {
-	strDateTime _tempDateTime;
-	_timeStamp += (unsigned long)(_timeZone *  3600.0); // adjust timezone
+	
 	if (_DayLightSaving ==1 && summerTime(_timeStamp)) _timeStamp += 3600; // European Summer time
 	if (_DayLightSaving ==2 && daylightSavingTime(_timeStamp)) _timeStamp += 3600; // US daylight time
+	_timeStamp += (unsigned long)(_timeZone *  3600.0); // adjust timezone
 	return _timeStamp;
 }
 


### PR DESCRIPTION
In Europe, the changeover to summer time takes place at the same time, but with different local times in different time zones. In your version, the changeover takes place in March at UTC+3 and is reversed in October UTC+3, which is correct if you are in EET (Eastern European Time).
In the new version, the changeover is set to UTC 01:00, so it works correctly in any time zone.
In the USA, it is tied to local time.
Always at 2 am. local time.
In spring, local time = UTC + time zone. (it will became 3 am. with DST)
In autumn local time = UTC+ time zone + DST (it will became 1 am. without DST).
Tricky. If we are checking  the UTC+time zone value, we have to change at 2 am. in spring and 1am in autumn. (wich is 2.am in local time both case.)
I corrected the code according to this.